### PR TITLE
fix(auth): resolve infinite redirect loop on onboarding completion

### DIFF
--- a/apps/web/src/modules/admin/pages/OnboardingWizard.tsx
+++ b/apps/web/src/modules/admin/pages/OnboardingWizard.tsx
@@ -95,6 +95,11 @@ export default function OnboardingWizard() {
   const { tenant, user, signOut, refreshProfile } = useAuth();
 
   useEffect(() => {
+    if (tenant?.onboarding_completed) {
+      navigate("/dashboard", { replace: true });
+      return;
+    }
+
     if (user && user.role) {
       const isOwnerOrAdmin =
         user.role.name === "owner" || user.role.name === "admin";
@@ -102,7 +107,7 @@ export default function OnboardingWizard() {
         navigate("/dashboard", { replace: true });
       }
     }
-  }, [user, navigate]);
+  }, [user, tenant, navigate]);
 
   const [currentStep, setCurrentStep] = useState(0);
   const [saving, setSaving] = useState(false);

--- a/apps/web/src/modules/auth/components/AuthGuard.tsx
+++ b/apps/web/src/modules/auth/components/AuthGuard.tsx
@@ -159,6 +159,14 @@ export function AuthGuard({ children }: AuthGuardProps) {
         }
       }
     } else {
+      // Eject from tenant onboarding routes if already completed
+      if (
+        location.pathname === "/onboarding" ||
+        location.pathname === "/pending-setup"
+      ) {
+        return <Navigate to="/dashboard" replace />;
+      }
+
       // --- Special case for Test User: always see onboarding once per session ---
       const isTestUser = user.email === "teste@leadgers.com";
       const hasSeenTour = sessionStorage.getItem("has_seen_tour");
@@ -179,6 +187,13 @@ export function AuthGuard({ children }: AuthGuardProps) {
         if (!isOwnerOrAdmin) {
           return <Navigate to="/user-onboarding" replace />;
         }
+      } else if (
+        (user.user_onboarding_completed || isOwnerOrAdmin) &&
+        location.pathname === "/user-onboarding" &&
+        !(isTestUser && !hasSeenTour)
+      ) {
+        // Eject if already completed user onboarding, or not required
+        return <Navigate to="/dashboard" replace />;
       }
     }
   } else if (user && !tenant) {

--- a/apps/web/src/modules/auth/pages/UserOnboardingPage.tsx
+++ b/apps/web/src/modules/auth/pages/UserOnboardingPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { supabase } from "../../../config/supabase";
 import { useAuth } from "../context/AuthContext";
@@ -20,6 +20,12 @@ export function UserOnboardingPage() {
   const [loading, setLoading] = useState(false);
   const [step, setStep] = useState(1);
   const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (user?.user_onboarding_completed) {
+      navigate("/dashboard", { replace: true });
+    }
+  }, [user, navigate]);
 
   const handleFinish = async () => {
     if (!user) return;


### PR DESCRIPTION
Analyzed the authentication and onboarding flow and identified a race condition in the AuthGuard. \n\nChanges:\n- **AuthGuard.tsx**: Added active ejection logic for users on onboarding routes (/onboarding, /pending-setup, /user-onboarding) when their status is already marked as completed.\n- **OnboardingWizard.tsx**: Added early ejection check in useEffect.\n- **UserOnboardingPage.tsx**: Added early ejection check in useEffect.\n\nVerified with local checklist and typechecks.