### PR TITLE
⚡ Bolt: Optimize runway projection headcount calculation

### DIFF
--- a/apps/api/src/routes/finance/runway.ts
+++ b/apps/api/src/routes/finance/runway.ts
@@ -63,6 +63,14 @@ runwayRoutes.post("/", async (c) => {
     },
   });
 
+  // ⚡ Bolt: Pre-calculate headcount costs by month to avoid O(N*M) recalculations in the projection loop
+  const headcountCostsByMonth = headcountPlans.reduce((acc: Record<string, number>, plan: any) => {
+    const startDate = new Date(plan.expected_start_date);
+    const key = `${startDate.getFullYear()}-${startDate.getMonth()}`;
+    acc[key] = (acc[key] || 0) + Number(plan.monthly_salary);
+    return acc;
+  }, {} as Record<string, number>);
+
   const results = scenarios.map((params: any) => {
     const data = [];
     let balance = cashBalance;
@@ -105,18 +113,8 @@ runwayRoutes.post("/", async (c) => {
       const nextMonthDate = new Date();
       nextMonthDate.setMonth(nextMonthDate.getMonth() + m + 1);
 
-      const newHeadcountMonthlyCost = headcountPlans
-        .filter((plan: any) => {
-          const startDate = new Date(plan.expected_start_date);
-          return (
-            startDate.getMonth() === nextMonthDate.getMonth() &&
-            startDate.getFullYear() === nextMonthDate.getFullYear()
-          );
-        })
-        .reduce(
-          (sum: number, plan: any) => sum + Number(plan.monthly_salary),
-          0,
-        );
+      // ⚡ Bolt: O(1) dictionary lookup instead of filtering and reducing the entire array on every iteration
+      const newHeadcountMonthlyCost = headcountCostsByMonth[`${nextMonthDate.getFullYear()}-${nextMonthDate.getMonth()}`] || 0;
 
       expenses += newHeadcountMonthlyCost;
     }


### PR DESCRIPTION
This PR optimizes the calculation of headcount costs in the `/finance/runway` endpoint. Previously, the logic filtered and reduced the entire `headcountPlans` array on every iteration of the projection loops (`Scenarios * Months`). This PR introduces a `headcountCostsByMonth` dictionary that pre-calculates costs outside the loops, turning the internal calculation into a simple `O(1)` lookup. This significantly reduces redundant computations and improves the performance of the runway projection API.

---
*PR created automatically by Jules for task [17041561027814444398](https://jules.google.com/task/17041561027814444398) started by @xXYoungMoreXx*