### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Cloudflare Turnstile CAPTCHA Bypass

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,8 @@
+## 2024-11-20 - [CRITICAL] Cloudflare Turnstile Bypass via localStorage
+
+**Vulnerability:** A hardcoded `localStorage` key named `LEADGERS_AUTOMATION_BYPASS` was being checked in `LoginPage.tsx` and `AcceptInvitePage.tsx`. If set to `"true"`, it entirely bypassed the Cloudflare Turnstile CAPTCHA validation. Any user or bot could easily set this key in their browser console to bypass the CAPTCHA protection, allowing brute-forcing or credential stuffing.
+**Learning:** This bypass was likely introduced to facilitate End-to-End (E2E) testing (e.g., Playwright scripts). However, leaving testing bypass mechanisms in production code is a critical security vulnerability.
+**Prevention:**
+- Never implement custom bypass logic in production code for testing purposes.
+- Use the official "Always Passes" test keys provided by security services (like Turnstile's `1x00000000000000000000AA`) which are designed to be safe for testing and won't compromise production environments if configured properly.
+- Ensure E2E tests are configured to use these standard test keys instead of injecting client-side bypass flags.

--- a/apps/web/src/modules/auth/pages/AcceptInvitePage.tsx
+++ b/apps/web/src/modules/auth/pages/AcceptInvitePage.tsx
@@ -99,10 +99,8 @@ export function AcceptInvitePage() {
     // Captcha validation check
     const siteKey = import.meta.env.VITE_TURNSTILE_SITE_KEY;
     const isTestKey = siteKey === "1x00000000000000000000AA";
-    const automationBypass =
-      localStorage.getItem("LEADGERS_AUTOMATION_BYPASS") === "true";
 
-    if (siteKey && !turnstileToken && !isTestKey && !automationBypass) {
+    if (siteKey && !turnstileToken && !isTestKey) {
       setError("Por favor, confirme que você não é um robô.");
       return;
     }
@@ -401,9 +399,7 @@ export function AcceptInvitePage() {
                       (!!import.meta.env.VITE_TURNSTILE_SITE_KEY &&
                         !turnstileToken &&
                         import.meta.env.VITE_TURNSTILE_SITE_KEY !==
-                          "1x00000000000000000000AA" &&
-                        localStorage.getItem("LEADGERS_AUTOMATION_BYPASS") !==
-                          "true")
+                          "1x00000000000000000000AA")
                     }
                     className={
                       btnPrimary +

--- a/apps/web/src/modules/auth/pages/LoginPage.tsx
+++ b/apps/web/src/modules/auth/pages/LoginPage.tsx
@@ -36,10 +36,8 @@ export function LoginPage() {
     // Captcha validation
     const siteKey = import.meta.env.VITE_TURNSTILE_SITE_KEY;
     const isTestKey = siteKey === "1x00000000000000000000AA";
-    const automationBypass =
-      localStorage.getItem("LEADGERS_AUTOMATION_BYPASS") === "true";
 
-    if (siteKey && !turnstileToken && !isTestKey && !automationBypass) {
+    if (siteKey && !turnstileToken && !isTestKey) {
       setError("Por favor, confirme que você não é um robô.");
       return;
     }
@@ -327,8 +325,7 @@ export function LoginPage() {
                   ) &&
                   !turnstileToken &&
                   import.meta.env.VITE_TURNSTILE_SITE_KEY !==
-                    "1x00000000000000000000AA" &&
-                  localStorage.getItem("LEADGERS_AUTOMATION_BYPASS") !== "true")
+                    "1x00000000000000000000AA")
               }
               className="group w-full bg-primary text-primary-foreground py-4 text-xs font-bold tracking-[0.2em] uppercase hover:brightness-110 shadow-xl shadow-primary/20 focus:outline-none focus:ring-4 focus:ring-primary/30 disabled:opacity-50 transition-all duration-300 rounded-2xl active:scale-[0.98] flex items-center justify-center gap-2 mt-4"
             >

--- a/scripts/e2e-audit-menus.ts
+++ b/scripts/e2e-audit-menus.ts
@@ -15,11 +15,6 @@ async function runTest() {
     viewport: { width: 1280, height: 800 },
   });
 
-  // Bypass Turnstile
-  await context.addInitScript(() => {
-    localStorage.setItem("LEADGERS_AUTOMATION_BYPASS", "true");
-  });
-
   const page = await context.newPage();
 
   page.on("console", (msg) => {

--- a/scripts/e2e-user-registration.ts
+++ b/scripts/e2e-user-registration.ts
@@ -191,11 +191,6 @@ async function main() {
       timezoneId: "America/Sao_Paulo",
     });
 
-    // Set automation bypass for Turnstile
-    await context.addInitScript(() => {
-      localStorage.setItem("LEADGERS_AUTOMATION_BYPASS", "true");
-    });
-
     const page = await context.newPage();
 
     // ── Step 1: Landing Page ──────────────────────────────


### PR DESCRIPTION
Removed the `LEADGERS_AUTOMATION_BYPASS` localStorage bypass for Cloudflare Turnstile CAPTCHA.
This backdoor was likely used for E2E testing but completely bypassed security checks.
Removed from `LoginPage.tsx`, `AcceptInvitePage.tsx` and removed injection points in `e2e-user-registration.ts` and `e2e-audit-menus.ts`. E2E tests should now only rely on the standard `1x...` Turnstile testing keys.

---
*PR created automatically by Jules for task [17422312999790351879](https://jules.google.com/task/17422312999790351879) started by @xXYoungMoreXx*