### PR TITLE
⚡ Bolt: [performance improvement] optimize chartData calculation in CashFlow.tsx

### DIFF
--- a/apps/web/src/modules/finance/pages/CashFlow.tsx
+++ b/apps/web/src/modules/finance/pages/CashFlow.tsx
@@ -47,6 +47,8 @@ export default function CashFlow() {
   const summary = getMonthSummary();
 
   // Prepara dados para o gráfico
+  // ⚡ Bolt: Use O(1) Map lookup instead of O(N) Array.find inside O(M) loop
+  const accountMap = new Map(accounts.map((a) => [a.id, a]));
   const chartData = transactions.reduce(
     (acc, transaction) => {
       const dateKey = formatDate(transaction.date);
@@ -55,12 +57,8 @@ export default function CashFlow() {
         acc[dateKey] = { date: dateKey, inflow: 0, outflow: 0 };
       }
 
-      const creditAccount = accounts.find(
-        (a) => a.id === transaction.accountCreditId,
-      );
-      const debitAccount = accounts.find(
-        (a) => a.id === transaction.accountDebitId,
-      );
+      const creditAccount = accountMap.get(transaction.accountCreditId);
+      const debitAccount = accountMap.get(transaction.accountDebitId);
 
       if (creditAccount?.type === "Receita") {
         acc[dateKey].inflow += transaction.amount;
@@ -336,12 +334,8 @@ export default function CashFlow() {
             </thead>
             <tbody className="divide-y divide-white/5">
               {transactions.map((transaction) => {
-                const debitAccount = accounts.find(
-                  (a) => a.id === transaction.accountDebitId,
-                );
-                const creditAccount = accounts.find(
-                  (a) => a.id === transaction.accountCreditId,
-                );
+                const debitAccount = accountMap.get(transaction.accountDebitId);
+                const creditAccount = accountMap.get(transaction.accountCreditId);
 
                 return (
                   <tr


### PR DESCRIPTION
💡 What: Replaced O(N) Array.find calls inside O(M) loops with an O(1) Map lookup.
🎯 Why: The previous implementation performed multiple `accounts.find()` calls inside `transactions.reduce()` and `transactions.map()`. This resulted in O(N*M) time complexity, potentially causing UI stuttering with many transactions/accounts.
📊 Impact: Reduces time complexity from O(N*M) to O(N + M). Prevents main-thread blocking on large datasets.
🔬 Measurement: Verify rendering performance in the CashFlow dashboard when dealing with >1000 transactions.

---
*PR created automatically by Jules for task [16599713755687247781](https://jules.google.com/task/16599713755687247781) started by @xXYoungMoreXx*