### PR TITLE
🛡️ Sentinel: [HIGH] Remove Google API Key from frontend

### DIFF
--- a/apps/web/src/modules/audit/hooks/useGoogleDrive.ts
+++ b/apps/web/src/modules/audit/hooks/useGoogleDrive.ts
@@ -10,7 +10,6 @@ import type { AuditReport } from "../types/audit.types";
  */
 
 const GOOGLE_CLIENT_ID = import.meta.env.VITE_GOOGLE_CLIENT_ID ?? "";
-const GOOGLE_API_KEY = import.meta.env.VITE_GOOGLE_API_KEY ?? "";
 const DRIVE_SCOPE = "https://www.googleapis.com/auth/drive.file";
 const DRIVE_UPLOAD_URL = "https://www.googleapis.com/upload/drive/v3/files";
 const DRIVE_FOLDER_NAME = "Leadgers Governance Reports";
@@ -88,7 +87,7 @@ export function useGoogleDrive() {
     async (token: string): Promise<string> => {
       // Search for existing folder
       const searchRes = await fetch(
-        `https://www.googleapis.com/drive/v3/files?q=name='${DRIVE_FOLDER_NAME}' and mimeType='application/vnd.google-apps.folder' and trashed=false&key=${GOOGLE_API_KEY}`,
+        `https://www.googleapis.com/drive/v3/files?q=name='${DRIVE_FOLDER_NAME}' and mimeType='application/vnd.google-apps.folder' and trashed=false`,
         { headers: { Authorization: `Bearer ${token}` } },
       );
       const searchData = await searchRes.json();


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Remove Google API Key from frontend

**🚨 Severity:** HIGH
**💡 Vulnerability:** Unnecessary bundling of the Google API Key into the frontend and exposing it in URL query strings.
**🎯 Impact:** Hardcoded API keys can be scraped from the client side. Passing them in URLs can lead to them being logged in browser history, network proxies, and server access logs.
**🔧 Fix:** Removed the `GOOGLE_API_KEY` and the `VITE_GOOGLE_API_KEY` references. The Google Drive API requests are already authenticated using the `Authorization: Bearer ${token}` header, so the key is redundant.
**✅ Verification:** Run `npm run typecheck`, `npm run lint`, and `npm run test` to verify no regressions.

---
*PR created automatically by Jules for task [4666378941015417992](https://jules.google.com/task/4666378941015417992) started by @xXYoungMoreXx*